### PR TITLE
Fix typo in Phabricator URL in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # prose-lint for arc
 
-prose-lint is a lint engine for use with [Phabricator](phabricator.org)'s `arc` command line tool.
+prose-lint is a lint engine for use with [Phabricator](http://phabricator.org)'s `arc` command line tool.
 It uses the open source [proselint](http://proselint.com/) tool.
 
 ## Features


### PR DESCRIPTION
The expanded URL was `https://github.com/google/arc-proselint/blob/develop/phabricator.org` instead of `http://phabricator.org/`.
